### PR TITLE
Daemonset for Fluent-bit with monitoring script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# k2-logging-fluent-bit-daemonset
-Fluent-bit Daemonset for Kubernetes Logging
+# Fluent-bit Daemonset for Kubernetes Logging
+
+[Fluent-bit](http://fluentbit.io/) daemonset dependencies for Kubernetes logging. The docker image for this repo is located at: quay.io/samsung_cnct/k2-logging-fluent-bit-daemonset.
+
+Currently this daemonset reads Docker logs from var/log/containers, adds Kubernetes pod metadata and writes to a zookeeper/Kafka component.
+
+## Bootstrap
+```
+kubectl create -f fluent-bit.yaml
+```
+
+## Plugins
+
+#### Kubernetes Metadata Filter
+
+This filter adds the following data into the body of the log.
+* namespace
+* pod id
+* pod name
+* labels
+* host
+* container name
+* docker container id
+
+For more information on the filter or to see a list of configuration options: http://fluentbit.io/documentation/0.11/filter/kubernetes.html
+
+## Monitor Resource Consumption in Container
+
+There is an optional script in the init directory to monitor resource usage for Fluent-bit running in your cluster. By modifying your Dockerfile the script will pull CPU and memory consumption constantly. To use the script, replace the last line in the Dockerfile with:
+
+```
+CMD ["/start.sh"]
+```
+
+Rebuild your docker image and redeploy the daemonset with new docker image. The script will run, you can stress-test your logging system and when you want to examine the data you can pipe the logs from your daemonsets into a file (on your local machine) with:
+
+```
+$ kubectl logs Fluent-bit-daemon-example >> logs.dat
+```
+
+Grep the file for your metrics with:
+
+```
+$ grep "\[metrics\]" <logs.dat> | cut -d" " -f2,3 > <clean.dat>
+```
+
+You will have two columns, CPU & MEM, which you can graph or pinpoint peak usage related to your stress testing. 
+
+GNUPLOT is an easy way to quickly visualize the data. Start GNUPLOT (install if necessary) and run: 
+
+`gnuplot> plot '<clean.dat>' using 1 with lines` for CPU usage
+`gnuplot> plot '<clean.dat>' using 2 with lines` for MEM usage

--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ This filter adds the following data into the body of the log.
 
 For more information on the filter or to see a list of configuration options: http://fluentbit.io/documentation/0.11/filter/kubernetes.html
 
+## Write Logs to Elasticsearch
+
+To write logs directly to Elasticsearch, modify your fluent-bit.conf. Remove the out_kafka output plugin and add:
+```
+[OUTPUT]
+    Name  es
+    Match *
+    Host  ${FLUENT_ELASTICSEARCH_HOST}
+    Port  ${FLUENT_ELASTICSEARCH_PORT}
+    Logstash_Format On
+    Retry_Limit False
+```
+
+Add these environment variables to the fluent-bit.yaml after line 20:
+```
+  env:
+    - name:  FLUENT_ELASTICSEARCH_HOST
+      value: "elasticsearch"
+    - name:  FLUENT_ELASTICSEARCH_PORT
+      value: "9200"
+```
+
+You will have to rebuild a custom Docker image with these changes. Put your new Docker image link in your fluent-bit.yaml file on line 20.
+
 ## Monitor Resource Consumption in Container
 
 There is an optional script in the init directory to monitor resource usage for Fluent-bit running in your cluster. By modifying your Dockerfile the script will pull CPU and memory consumption constantly. To use the script, replace the last line in the Dockerfile with:

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  labels:
+    app: log-app
+    k8s-app: fluent-bit-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluent-bit-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: fluent-bit
+        image: leahnp/fb-kafka
+        # option env variables if directing logs to elasticsearch
+        env:
+          - name:  FLUENT_ELASTICSEARCH_HOST
+            value: "elasticsearch"
+          - name:  FLUENT_ELASTICSEARCH_PORT
+            value: "9200"
+        resources:
+          # TODO: test this memory limit, April 2017, this limit was being hit on startup
+          # if there were a lot of logs already existing in /var/lib/docker/containers
+          # limits:
+          #   memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -17,18 +17,13 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: leahnp/fb-kafka
-        # option env variables if directing logs to elasticsearch
+        image: quay.io/samsung_cnct/k2-logging-fluent-bit-daemonset:latest
         env:
           - name:  FLUENT_ELASTICSEARCH_HOST
             value: "elasticsearch"
           - name:  FLUENT_ELASTICSEARCH_PORT
             value: "9200"
         resources:
-          # TODO: test this memory limit, April 2017, this limit was being hit on startup
-          # if there were a lot of logs already existing in /var/lib/docker/containers
-          # limits:
-          #   memory: 100Mi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -18,11 +18,6 @@ spec:
       containers:
       - name: fluent-bit
         image: quay.io/samsung_cnct/k2-logging-fluent-bit-daemonset:latest
-        env:
-          - name:  FLUENT_ELASTICSEARCH_HOST
-            value: "elasticsearch"
-          - name:  FLUENT_ELASTICSEARCH_PORT
-            value: "9200"
         resources:
           requests:
             cpu: 100m

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu
+ENV DEBIAN_FRONTEND noninteractive
+
+# Fluent Bit version
+ENV FLB_MAJOR 0
+ENV FLB_MINOR 11
+ENV FLB_PATCH 3
+ENV FLB_VERSION 0.11.3
+ENV GOPATH /go
+ENV GOBIN $GOPATH/bin
+ENV PATH $GOBIN:$PATH
+
+MAINTAINER Leah Petersen <leahnpetersen@gmail.com>
+LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.1"
+USER root
+
+# Install build tools
+RUN apt-get -qq update && \
+    apt-get install -y -qq curl ca-certificates build-essential cmake iputils-ping dnsutils make bash sudo wget unzip nano vim valgrind golang git  && \
+    apt-get install -y -qq --reinstall lsb-base lsb-release && \
+    wget -O "/tmp/fluent-bit-$FLB_VERSION-dev.zip" "http://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip" && \
+    cd /tmp && \
+    unzip "fluent-bit-$FLB_VERSION-dev.zip" && \
+    cd "fluent-bit-$FLB_VERSION/build/" && \
+    cmake -DCMAKE_INSTALL_PREFIX=/fluent-bit/ .. && \
+    make && make install && \
+    cd / && \
+    git clone https://github.com/samsung-cnct/fluent-bit-kafka-output-plugin && \
+    cd fluent-bit-kafka-output-plugin && \
+    make && \
+    rm -rf /tmp/* /fluent-bit/include /fluent-bit/lib*
+
+COPY fluent-bit.conf /fluent-bit/etc/
+COPY parsers.conf /fluent-bit/etc/
+COPY start.sh /
+RUN ["chmod", "+x", "/start.sh"]
+
+CMD ["/fluent-bit/bin/fluent-bit", "-e", "/fluent-bit-kafka-output-plugin/out_kafka.so", "-c", "/fluent-bit/etc/fluent-bit.conf"]

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -18,7 +18,7 @@ USER root
 RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential cmake iputils-ping dnsutils make bash sudo wget unzip nano vim valgrind golang git  && \
     apt-get install -y -qq --reinstall lsb-base lsb-release && \
-    wget -O "/tmp/fluent-bit-$FLB_VERSION-dev.zip" "http://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip" && \
+    wget -O "/tmp/fluent-bit-$FLB_VERSION-dev.zip" "https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip" && \
     cd /tmp && \
     unzip "fluent-bit-$FLB_VERSION-dev.zip" && \
     cd "fluent-bit-$FLB_VERSION/build/" && \

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -1,0 +1,20 @@
+[SERVICE]
+    Flush        1
+    Daemon       Off
+    Log_Level    info
+    Parsers_File parsers.conf
+
+[INPUT]
+    Name          tail
+    Path          /var/log/containers/log*.log
+    Parser        docker
+    Tag           kube.*
+    Mem_Buf_Limit 5MB
+
+[FILTER]
+    Name   kubernetes
+    Match  kube.*
+
+[OUTPUT]
+    Name  out_kafka
+    Match *

--- a/init/parsers.conf
+++ b/init/parsers.conf
@@ -1,0 +1,45 @@
+[PARSER]
+    Name   apache
+    Format regex
+    Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name   apache2
+    Format regex
+    Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name   apache_error
+    Format regex
+    Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
+
+[PARSER]
+    Name   nginx
+    Format regex
+    Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name   json-test
+    Format json
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name        docker
+    Format      json
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S
+    Time_Keep   On
+
+[PARSER]
+    Name        syslog
+    Format      regex
+    Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+    Time_Key    time
+    Time_Format %b %d %H:%M:%S

--- a/init/start.sh
+++ b/init/start.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+
+# start fluent-bit and get PID to monitor resource consumption
+/fluent-bit/bin/fluent-bit -v -e /fluent-bit-kafka-output-plugin/out_kafka.so -c /fluent-bit/etc/fluent-bit.conf &
+
+# get process id of last ran command (fluentd)
+PID=$!
+echo "my PID is $PID"
+
+# start monitoring fluent-bit
+# warning - this will run forever
+# set a time cap or manually delete
+# after tests have been ran.
+while [ 1 ]; do
+
+CPU=$(ps -p $PID -o %cpu=)
+MEM=$(ps -p $PID -o rss=)
+echo "[metrics]: $CPU $MEM"
+
+sleep 2
+done
+
+# wait for fluent-bit to exit
+wait $PID

--- a/init/start.sh
+++ b/init/start.sh
@@ -10,7 +10,7 @@ echo "my PID is $PID"
 # start monitoring fluent-bit
 # warning - this will run forever
 # set a time cap or manually delete
-# after tests have been ran.
+# after tests have ran.
 while [ 1 ]; do
 
 CPU=$(ps -p $PID -o %cpu=)


### PR DESCRIPTION
Daemonset to run Fluent-bit in the central logging pipeline. Currently configured to pull logs from docker containers, enrich with Kubernetes meta-data and send to Kafka. Also has configurations to send to Elasticsearch. Script and instructions on how to monitor resource usage in container also included but not configured by default. 

To review: deploy central logging pipeline WITHOUT fluentd daemonset, deploy this daemonset and check logs are being retrieved and forwarded. Optionally test monitoring script as well (in idling and high volume situations, Fluent-bit uses 10 times less memory than Fluentd).