### PR TITLE
ignoring self logs, expand to read all other logs

### DIFF
--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -6,7 +6,8 @@
 
 [INPUT]
     Name          tail
-    Path          /var/log/containers/log*.log
+    Path          /var/log/containers/*.log
+    Exclude_Path  /var/log/containers/fluent*.log
     Parser        docker
     Tag           kube.*
     Mem_Buf_Limit 5MB


### PR DESCRIPTION
Config file change to ignore fluent-bit (self) logs and read logs from all other containers. This config is for the common tool production cluster environment. 