### PR TITLE
Systemd plugin running and logging from /var/lib/journal inside pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Fluent-bit](http://fluentbit.io/) daemonset dependencies for Kubernetes logging. The docker image for this repo is located at: quay.io/samsung_cnct/k2-logging-fluent-bit-daemonset.
 
-Currently this daemonset reads Docker logs from var/log/containers, adds Kubernetes pod metadata and writes to a zookeeper/Kafka component.
+Currently this daemonset reads Docker logs from var/log/containers, journal logs from /var/log/journal, adds Kubernetes pod metadata and writes to a zookeeper/Kafka component.
 
 ## Bootstrap
 ```
@@ -10,6 +10,8 @@ kubectl create -f fluent-bit.yaml
 ```
 
 ## Plugins
+
+####
 
 #### Kubernetes Metadata Filter
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ kubectl create -f fluent-bit.yaml
 
 ## Plugins
 
-####
+#### Systemd Input Plugin
+
+This input plugin reads from /var/log/journal, which contains kernel, dockerd, and rkt logs, among others. It is new as of v0.12.
+More informaton on this plugin can be found at:
+http://fluentbit.io/documentation/0.12/input/systemd.html
+
+#### Tail Input Plugin
+
+This input plugin monitors text files as matched by a specified Path; in this case, /var/log/containers/*.log, excluding   /var/log/containers/fluent\*.log.
+More informaton on this plugin can be found at:
+http://fluentbit.io/documentation/0.12/input/tail.html
 
 #### Kubernetes Metadata Filter
 
@@ -24,7 +34,7 @@ This filter adds the following data into the body of the log.
 * container name
 * docker container id
 
-For more information on the filter or to see a list of configuration options: http://fluentbit.io/documentation/0.11/filter/kubernetes.html
+For more information on the filter or to see a list of configuration options: http://fluentbit.io/documentation/0.12/filter/kubernetes.html
 
 ## Write Logs to Elasticsearch
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Fluent-bit](http://fluentbit.io/) daemonset dependencies for Kubernetes logging. The docker image for this repo is located at: quay.io/samsung_cnct/k2-logging-fluent-bit-daemonset.
 
-Currently this daemonset reads Docker logs from var/log/containers, journal logs from /var/log/journal, adds Kubernetes pod metadata and writes to a zookeeper/Kafka component.
+Currently this daemonset reads [Docker logs](https://docs.docker.com/engine/admin/logging/overview/) from `/var/log/containers` and [journald logs](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html) from `/var/log/journal`. It adds Kubernetes metadata to the logs and writes them to stdout.
 
 ## Bootstrap
 ```

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -63,6 +63,10 @@ spec:
       serviceAccountName: fluentbit-daemon
       containers:
       - name: fluent-bit
+        securityContext:
+          capabilities:
+            drop:
+              - SYSLOG
         image: quay.io/guineveresaenger/k2-logging-fluent-bit-daemonset:latest
         resources:
           requests:
@@ -74,9 +78,13 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
-        - name: kmsg
-          mountPath: /dev
-
+      # - name: dmesg-logs
+      #   image: debian        
+      #   command: ["/bin/sh"]
+      #   args: ["-c", "while true; do dmesg > /var/log/dmesg-logs; sleep 10; done"]
+      #   volumeMounts:
+      #   - name: varlog
+      #     mountPath: /var/log
       terminationGracePeriodSeconds: 10
       volumes:
       - name: varlog
@@ -85,6 +93,3 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
-      - name: kmsg
-        hostPath:
-          path: /dev

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -78,13 +78,6 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
-      # - name: dmesg-logs
-      #   image: debian        
-      #   command: ["/bin/sh"]
-      #   args: ["-c", "while true; do dmesg > /var/log/dmesg-logs; sleep 10; done"]
-      #   volumeMounts:
-      #   - name: varlog
-      #     mountPath: /var/log
       terminationGracePeriodSeconds: 10
       volumes:
       - name: varlog

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: fluentbit-daemon
       containers:
       - name: fluent-bit
-        image: quay.io/samsung_cnct/k2-logging-fluent-bit-daemonset:latest
+        image: quay.io/guineveresaenger/k2-logging-fluent-bit-daemonset:latest
         resources:
           requests:
             cpu: 100m

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -67,7 +67,7 @@ spec:
           capabilities:
             drop:
               - SYSLOG
-        image: quay.io/guineveresaenger/k2-logging-fluent-bit-daemonset:latest
+        image: quay.io/samsung_cnct/k2-logging-fluent-bit-daemonset:latest
         resources:
           requests:
             cpu: 100m

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -74,6 +74,9 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        - name: kmsg
+          mountPath: /dev/kmsg
+
       terminationGracePeriodSeconds: 10
       volumes:
       - name: varlog
@@ -82,3 +85,6 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -66,7 +66,7 @@ spec:
         securityContext:
           capabilities:
             add:
-              - CAP_SYSLOG
+              - SYSLOG
 
         image: quay.io/guineveresaenger/k2-logging-fluent-bit-daemonset:latest
         resources:

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -63,6 +63,9 @@ spec:
       serviceAccountName: fluentbit-daemon
       containers:
       - name: fluent-bit
+        securityContext:
+          privileged: true
+
         image: quay.io/guineveresaenger/k2-logging-fluent-bit-daemonset:latest
         resources:
           requests:

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -75,7 +75,8 @@ spec:
           mountPath: /var/lib/docker/containers
           readOnly: true
         - name: kmsg
-          mountPath: /dev/kmsg
+          mountPath: /dev
+          readOnly: true
 
       terminationGracePeriodSeconds: 10
       volumes:
@@ -87,4 +88,4 @@ spec:
           path: /var/lib/docker/containers
       - name: kmsg
         hostPath:
-          path: /dev/kmsg
+          path: /dev

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -76,7 +76,6 @@ spec:
           readOnly: true
         - name: kmsg
           mountPath: /dev
-          readOnly: true
 
       terminationGracePeriodSeconds: 10
       volumes:

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -64,7 +64,9 @@ spec:
       containers:
       - name: fluent-bit
         securityContext:
-          privileged: true
+          capabilities:
+            add:
+              - CAP_SYSLOG
 
         image: quay.io/guineveresaenger/k2-logging-fluent-bit-daemonset:latest
         resources:

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -63,11 +63,6 @@ spec:
       serviceAccountName: fluentbit-daemon
       containers:
       - name: fluent-bit
-        securityContext:
-          capabilities:
-            add:
-              - SYSLOG
-
         image: quay.io/guineveresaenger/k2-logging-fluent-bit-daemonset:latest
         resources:
           requests:

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -63,10 +63,6 @@ spec:
       serviceAccountName: fluentbit-daemon
       containers:
       - name: fluent-bit
-        securityContext:
-          capabilities:
-            drop:
-              - SYSLOG
         image: quay.io/samsung_cnct/k2-logging-fluent-bit-daemonset:latest
         resources:
           requests:

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -28,8 +28,7 @@ RUN apt-get -qq update && \
     git clone https://github.com/samsung-cnct/fluent-bit-kafka-output-plugin && \
     cd fluent-bit-kafka-output-plugin && \
     make && \
-    rm -rf /tmp/* /fluent-bit/include /fluent-bit/lib* && \
-    apt-get install systemd
+    rm -rf /tmp/* /fluent-bit/include /fluent-bit/lib*
 
 COPY fluent-bit.conf /fluent-bit/etc/
 COPY parsers.conf /fluent-bit/etc/

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -17,8 +17,7 @@ USER root
 # Install build tools
 RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential cmake iputils-ping dnsutils make bash sudo wget unzip libsystemd-dev nano vim valgrind golang git  && \
-    apt-get install -y -qq --reinstall lsb-base lsb-release && \
-    
+    apt-get install -y -qq --reinstall lsb-base lsb-release && \  
     wget -O "/tmp/fluent-bit-$FLB_VERSION-dev.zip" "https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip" && \
     cd /tmp && \
     unzip "fluent-bit-$FLB_VERSION-dev.zip" && \

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -16,8 +16,9 @@ USER root
 
 # Install build tools
 RUN apt-get -qq update && \
-    apt-get install -y -qq curl ca-certificates build-essential cmake iputils-ping dnsutils make bash sudo wget unzip nano vim valgrind golang git  && \
+    apt-get install -y -qq curl ca-certificates build-essential cmake iputils-ping dnsutils make bash sudo wget unzip libsystemd-dev nano vim valgrind golang git  && \
     apt-get install -y -qq --reinstall lsb-base lsb-release && \
+    
     wget -O "/tmp/fluent-bit-$FLB_VERSION-dev.zip" "https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip" && \
     cd /tmp && \
     unzip "fluent-bit-$FLB_VERSION-dev.zip" && \

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get -qq update && \
     git clone https://github.com/samsung-cnct/fluent-bit-kafka-output-plugin && \
     cd fluent-bit-kafka-output-plugin && \
     make && \
-    rm -rf /tmp/* /fluent-bit/include /fluent-bit/lib*
+    rm -rf /tmp/* /fluent-bit/include /fluent-bit/lib* && \
+    apt-get install systemd
 
 COPY fluent-bit.conf /fluent-bit/etc/
 COPY parsers.conf /fluent-bit/etc/

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -1,14 +1,7 @@
-[SERVICE]
-    Flush        1
-    Log_Level    info
-    Parsers_File parsers.conf
-
-
 [INPUT]
-    Name            systemd
-    Tag             host.*
-    Systemd_Filter  _SYSTEMD_UNIT=docker.service
-    Path            /var/log/journal
+    Name                tail
+    Path                /var/log/journal
+    Buffer_Chunk_Size   64k
 
 [OUTPUT]
     Name   stdout

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -11,6 +11,7 @@
     Parser        docker
     Tag           kube.*
     Mem_Buf_Limit 5MB
+    
 
 [FILTER]
     Name   kubernetes
@@ -19,3 +20,11 @@
 [OUTPUT]
     Name  out_kafka
     Match *
+
+[INPUT]
+    Name   kmsg
+    Tag    kernel
+
+[OUTPUT]
+    Name   stdout
+    Match  *

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -5,8 +5,9 @@
     Parsers_File parsers.conf
 
 [INPUT]
-    Name   tail
-    Path   /var/log/syslog
+    Name            systemd
+    Tag             host.*
+    Systemd_Filter  _SYSTEMD_UNIT=docker.service
 
 # [FILTER]
 #     Name   grep

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -5,8 +5,13 @@
     Parsers_File parsers.conf
 
 [INPUT]
-    Name   kmsg
-    Tag    node_kernel
+    Name   tail
+    Path   /var/log/syslog
+
+# [FILTER]
+#     Name   grep
+#     Match  *
+#     Regex  log ^.*kernel.*$
 
 [OUTPUT]
     Name   stdout

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -23,7 +23,7 @@
 
 [INPUT]
     Name   kmsg
-    Tag    kernel
+    Tag    node_kernel
 
 [OUTPUT]
     Name   stdout

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -5,23 +5,6 @@
     Parsers_File parsers.conf
 
 [INPUT]
-    Name          tail
-    Path          /var/log/containers/*.log
-    Exclude_Path  /var/log/containers/fluent*.log
-    Parser        docker
-    Tag           kube.*
-    Mem_Buf_Limit 5MB
-    
-
-[FILTER]
-    Name   kubernetes
-    Match  kube.*
-
-[OUTPUT]
-    Name  out_kafka
-    Match *
-
-[INPUT]
     Name   kmsg
     Tag    node_kernel
 

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -1,6 +1,6 @@
-[SERVER]
+[SERVICE]
     Flush        1
-    Log_Level    trace
+    Log_Level    info
     Parsers_File parsers.conf
 
 

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -4,7 +4,7 @@
     Parsers_File parsers.conf
 
 [INPUT]
-    Name            journald
+    Name            systemd
     Tag             host.*
     Systemd_Filter  _SYSTEMD_UNIT=docker.service
 

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -4,7 +4,7 @@
     Parsers_File parsers.conf
 
 [INPUT]
-    Name            systemd
+    Name            journald
     Tag             host.*
     Systemd_Filter  _SYSTEMD_UNIT=docker.service
 

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -6,8 +6,8 @@
 [INPUT]
     Name            systemd
     Tag             host.*
-    Systemd_Filter  _SYSTEMD_UNIT=docker.service
     Path            /var/log/journal
+    
 
 [OUTPUT]
     Name   stdout

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -1,13 +1,13 @@
-[SERVICE]
+[SERVER]
     Flush        1
-    Daemon       Off
+    # Daemon       Off
     Log_Level    info
     Parsers_File parsers.conf
 
 [INPUT]
-    Name            systemd
-    Tag             host.*
-    Systemd_Filter  _SYSTEMD_UNIT=docker.service
+    Name                systemd
+    Tag                 host.*
+    Systemd_Filter      _SYSTEMD_UNIT=docker.service
 
 # [FILTER]
 #     Name   grep

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -7,8 +7,21 @@
     Name            systemd
     Tag             host.*
     Path            /var/log/journal
-    
+
+[INPUT]
+    Name          tail
+    Path          /var/log/containers/*.log
+    Exclude_Path  /var/log/containers/fluent*.log
+    Parser        docker
+    Tag           kube.*
+    Mem_Buf_Limit 5MB
+
+[FILTER]
+    Name   kubernetes
+    Match  kube.*  
 
 [OUTPUT]
     Name   stdout
     Match  *
+
+    

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -1,7 +1,13 @@
+[SERVICE]
+    Flush        1
+    Log_Level    info
+    Parsers_File parsers.conf
+
 [INPUT]
-    Name                tail
-    Path                /var/log/journal
-    Buffer_Chunk_Size   64k
+    Name            systemd
+    Tag             host.*
+    Systemd_Filter  _SYSTEMD_UNIT=docker.service
+    Path            /var/log/journal
 
 [OUTPUT]
     Name   stdout

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -1,12 +1,14 @@
 [SERVICE]
     Flush        1
-    Log_Level    info
+    Log_Level    trace
     Parsers_File parsers.conf
+
 
 [INPUT]
     Name            systemd
     Tag             host.*
     Systemd_Filter  _SYSTEMD_UNIT=docker.service
+    Path            /var/log/journal
 
 [OUTPUT]
     Name   stdout

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -1,4 +1,4 @@
-[SERVICE]
+[SERVER]
     Flush        1
     Log_Level    trace
     Parsers_File parsers.conf

--- a/init/fluent-bit.conf
+++ b/init/fluent-bit.conf
@@ -1,18 +1,12 @@
-[SERVER]
+[SERVICE]
     Flush        1
-    # Daemon       Off
     Log_Level    info
     Parsers_File parsers.conf
 
 [INPUT]
-    Name                systemd
-    Tag                 host.*
-    Systemd_Filter      _SYSTEMD_UNIT=docker.service
-
-# [FILTER]
-#     Name   grep
-#     Match  *
-#     Regex  log ^.*kernel.*$
+    Name            systemd
+    Tag             host.*
+    Systemd_Filter  _SYSTEMD_UNIT=docker.service
 
 [OUTPUT]
     Name   stdout


### PR DESCRIPTION
ToReview:
- spin up a cluster
- deploy the fluent-bit daemonset on it
- run `kubectl logs <fluent-bit-pod>`
- watch logs!

Points of concern: 

- I am not entirely sure if this is just kernel messages, or other logs in addition, so it would be important to clarify.
- Currently, the docker image for the fluent-bit pods is a homemade one; when this code gets merged, we need to push a new official image and make sure the daemonset yaml reflects this.
